### PR TITLE
feat: add wiki api utility with rate limiting

### DIFF
--- a/tests/test_wiki_api.py
+++ b/tests/test_wiki_api.py
@@ -1,0 +1,70 @@
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _mock_response(data, status=200):
+    resp = MagicMock()
+    resp.getcode.return_value = status
+
+    import json
+
+    resp.read.return_value = json.dumps(data).encode()
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = None
+    return resp
+
+
+def _reload_module(monkeypatch):
+    """Reload ``utils.wiki_api`` so env changes take effect."""
+
+    import utils.wiki_api as wiki_api
+
+    importlib.reload(wiki_api)
+    return wiki_api
+
+
+def test_get_mapping_uses_cache(monkeypatch):
+    wiki_api = _reload_module(monkeypatch)
+    mock_resp = _mock_response([{"id": 1, "name": "Item"}])
+    with patch("utils.wiki_api.request.urlopen", return_value=mock_resp) as mock_get:
+        data1 = wiki_api.get_mapping()
+        data2 = wiki_api.get_mapping()
+        assert mock_get.call_count == 1
+        assert data1 == data2
+
+
+def test_user_agent_from_env(monkeypatch):
+    monkeypatch.setenv("USER_AGENT", "TEST-AGENT")
+    wiki_api = _reload_module(monkeypatch)
+    mock_resp = _mock_response({"data": {}})
+    with patch("utils.wiki_api.request.urlopen", return_value=mock_resp) as mock_get:
+        wiki_api.get_latest()
+        req = mock_get.call_args.args[0]
+        headers = {k.lower(): v for k, v in req.header_items()}
+        assert headers["user-agent"] == "TEST-AGENT"
+
+
+def test_get_timeseries_dataframe(monkeypatch):
+    wiki_api = _reload_module(monkeypatch)
+    mock_resp = _mock_response(
+        {"data": [{"timestamp": 0, "avgHighPrice": 10, "avgLowPrice": 8}]}
+    )
+    with patch("utils.wiki_api.request.urlopen", return_value=mock_resp):
+        data = wiki_api.get_timeseries(1, "1h")
+
+    assert data == [
+        {"timestamp": "1970-01-01 00:00:00", "avgHighPrice": 10, "avgLowPrice": 8}
+    ]
+
+
+def test_get_timeseries_bad_timestep(monkeypatch):
+    wiki_api = _reload_module(monkeypatch)
+    with pytest.raises(ValueError):
+        wiki_api.get_timeseries(1, "bad")
+

--- a/utils/wiki_api.py
+++ b/utils/wiki_api.py
@@ -1,67 +1,183 @@
-# utils/wiki_api.py
+"""Utility helpers for interacting with the Old School RuneScape Wiki price API.
+
+The real project will eventually wrap these helpers in higher level services, but
+for now we provide a small synchronous wrapper around the wiki endpoints with
+polite client side rate limiting and a custom user agent.  The functions in this
+module intentionally avoid raising exceptions so callers can decide how to handle
+failures gracefully.
+
+The functions implemented here are a subset of the behaviour described in the
+project specification.  They are designed to be small, easy to test and
+dependency free so they can be reused by both the backend API and the Discord
+bot.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
 import time
-import requests
-import pandas as pd
 from functools import lru_cache
+from typing import Dict, Iterable, List, Optional
+
+from urllib import request, error
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
 WIKI_BASE = "https://prices.runescape.wiki/api/v1/osrs"
 
-# Be a good API citizen: identify the app
-DEFAULT_HEADERS = {
-    "User-Agent": "OSRS-StockBot/1.0 (+https://github.com/depositcoins/osrs-stockbot)"
-}
 
-def _get_json(url: str, retries: int = 4, backoff: float = 0.75):
+def _user_agent() -> str:
+    """Return the User‑Agent string for outbound requests.
+
+    A default value is used when ``USER_AGENT`` is not defined.  The value is
+    read at call time rather than module import so tests can override the
+    environment variable with ``monkeypatch`` and reload this module.
     """
-    GET JSON with retries & exponential backoff.
-    Returns {} on failure so callers can handle gracefully.
+
+    return os.environ.get(
+        "USER_AGENT",
+        "OSRS-Merch-Bot/1.3 (contact: you@example.com)",
+    )
+
+
+# Maximum number of requests per second.  The API specification suggests at most
+# four requests per second across all endpoints.
+_MAX_RPS = 4
+_MIN_INTERVAL = 1 / _MAX_RPS
+_rate_lock = threading.Lock()
+_last_request = 0.0
+
+
+def _respect_rate_limit() -> None:
+    """Sleep if necessary to maintain the global request rate limit."""
+
+    global _last_request
+    with _rate_lock:
+        now = time.time()
+        wait = _MIN_INTERVAL - (now - _last_request)
+        if wait > 0:
+            time.sleep(wait)
+            now = time.time()
+        _last_request = now
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_json(url: str, retries: int = 4, backoff: float = 0.75) -> Dict:
+    """GET ``url`` returning parsed JSON.
+
+    The function retries on common transient errors with exponential backoff and
+    honours the global request rate limit.  On any failure an empty ``dict`` is
+    returned so callers can handle the absence of data as they see fit.
     """
+
     attempt = 0
     while True:
+        _respect_rate_limit()
         try:
-            resp = requests.get(url, headers=DEFAULT_HEADERS, timeout=20)
-            if resp.status_code == 200:
-                return resp.json()
-            # For 429/5xx, sleep then retry
-            if resp.status_code in (429, 500, 502, 503, 504):
-                attempt += 1
-                if attempt > retries:
-                    return {}
-                time.sleep(backoff * (2 ** (attempt - 1)))
-            else:
-                # Non-retryable error
+            req = request.Request(url, headers={"User-Agent": _user_agent()})
+            with request.urlopen(req, timeout=20) as resp:
+                status = resp.getcode()
+                if status == 200:
+                    import json
+
+                    return json.load(resp)
+                if status in {429, 500, 502, 503, 504}:
+                    attempt += 1
+                    if attempt > retries:
+                        return {}
+                    time.sleep(backoff * (2 ** (attempt - 1)))
+                    continue
                 return {}
-        except requests.RequestException:
+        except (error.HTTPError, error.URLError, TimeoutError, ValueError):
             attempt += 1
             if attempt > retries:
                 return {}
             time.sleep(backoff * (2 ** (attempt - 1)))
 
-@lru_cache(maxsize=1)
-def get_mapping() -> pd.DataFrame:
-    data = _get_json(f"{WIKI_BASE}/mapping")
-    df = pd.DataFrame(data) if isinstance(data, list) else pd.DataFrame([])
-    if df.empty:
-        return pd.DataFrame(columns=["id", "name"])
-    keep_cols = [c for c in ["id", "name", "examine", "members", "highalch"] if c in df.columns]
-    return df[keep_cols].dropna(subset=["id", "name"]).reset_index(drop=True)
 
-def get_latest(ids=None) -> dict:
+# ---------------------------------------------------------------------------
+# Public API wrappers
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_mapping() -> List[Dict]:
+    """Return the item mapping table as a list of dictionaries."""
+
+    data = _get_json(f"{WIKI_BASE}/mapping")
+    if not isinstance(data, list):
+        return []
+
+    allowed = {"id", "name", "examine", "members", "highalch"}
+    out = []
+    for row in data:
+        if not isinstance(row, dict) or "id" not in row or "name" not in row:
+            continue
+        out.append({k: row.get(k) for k in allowed if k in row})
+    return out
+
+
+def get_latest(ids: Optional[Iterable[int]] = None) -> Dict[str, Dict]:
+    """Fetch the latest price snapshot.
+
+    ``ids`` may be an iterable of integers.  When provided the returned mapping
+    is filtered to only those item ids.
+    """
+
     js = _get_json(f"{WIKI_BASE}/latest")
     prices = js.get("data", {}) if isinstance(js, dict) else {}
     if ids is None:
         return prices
+
     ids_str = {str(i) for i in ids}
     return {k: v for k, v in prices.items() if k in ids_str}
 
-def get_timeseries(item_id: int, timestep: str = "1h") -> pd.DataFrame:
+
+_ALLOWED_TIMESTEPS = {"5m", "1h", "6h", "24h"}
+
+
+def get_timeseries(item_id: int, timestep: str = "1h") -> List[Dict]:
+    """Return historic prices for ``item_id`` as a list of dictionaries.
+
+    Each dictionary contains ``timestamp`` (as a ``datetime`` object),
+    ``avgHighPrice`` and ``avgLowPrice``.  If anything goes wrong an empty list
+    is returned.
     """
-    Fetch price history. Returns empty DataFrame on failure (UI handles gracefully).
-    timestep ∈ {"5m","1h","6h"}.
-    """
+
+    if timestep not in _ALLOWED_TIMESTEPS:
+        raise ValueError(f"timestep must be one of {_ALLOWED_TIMESTEPS}")
+
     url = f"{WIKI_BASE}/timeseries?timestep={timestep}&id={item_id}"
     js = _get_json(url)
     data = js.get("data", []) if isinstance(js, dict) else []
     if not data:
-        return pd.DataFrame(columns=["timestamp", "avgHighPrice", "avgLowPrice"])
-    df = pd.DataFrame(data
+        return []
+
+    out: List[Dict] = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        ts = row.get("timestamp")
+        if ts is None:
+            continue
+        out.append(
+            {
+                "timestamp": time.strftime(
+                    "%Y-%m-%d %H:%M:%S", time.gmtime(int(ts))
+                ),
+                "avgHighPrice": row.get("avgHighPrice"),
+                "avgLowPrice": row.get("avgLowPrice"),
+            }
+        )
+    return out
+
+
+__all__ = ["get_mapping", "get_latest", "get_timeseries"]
+


### PR DESCRIPTION
## Summary
- add synchronous OSRS Wiki API helper with rate limiting and env-configurable user agent
- provide mapping, latest price, and timeseries helpers
- add tests covering caching, header injection, timeseries parsing, and invalid timestep handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52d1357308320bf3dabea75ddd28f